### PR TITLE
upgrade go to 1.21 and implement auto update lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: 'go.mod'
 
       - name: Test
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,11 +9,20 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
-      - uses: actions/checkout@v3
+          go-version-file: 'go.mod'
+      # This step sets up the variable steps.golangci-lint-version.outputs.v
+      # to contain the version of golangci-lint (e.g. v1.54.2).
+      # The version is taken from go.mod.
+      - name: Golangci-lint version
+        id: golangci-lint-version
+        run: |
+          GOLANGCI_LINT_VERSION=$( go list -m -f '{{.Version}}' github.com/golangci/golangci-lint )
+          echo "v=$GOLANGCI_LINT_VERSION" >> "$GITHUB_OUTPUT"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.3.0
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: ${{ steps.golangci-lint-version.outputs.v }}
+          skip-pkg-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: 'go.mod'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,9 @@ dep:
 	go mod download
 	go mod tidy
 
+.PHONY: install-tools
+install-tools:
+	@echo Installing tools from tools.go
+	@go list -e -f '{{ join .Imports "\n" }}' tools.go | xargs -tI % go install %
+	@go mod tidy
+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/conduitio-labs/conduit-connector-zendesk
 
-go 1.18
+go 1.21
+
+toolchain go1.21.1
 
 require (
 	github.com/conduitio/conduit-connector-sdk v0.4.0

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,21 @@
+// Copyright © 2023 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build tools
+
+package main
+
+import (
+	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
+)


### PR DESCRIPTION
### Description

Upgrades Go version to 1.21.0 and updates GH actions to use go.mod instead of a hard-coded Go version. Also modifies golangCI to implement lint version updater.

Fixes #998

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-databricks/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
